### PR TITLE
Completed BaseComponentSmall setup

### DIFF
--- a/src/components/InspectionForm.tsx
+++ b/src/components/InspectionForm.tsx
@@ -22,7 +22,9 @@ import { IReport } from "../data/Interfaces"
 // Template Component Import List
 import BaseComponentSmall from "../design/BaseComponentSmall"
 
-const InspectionForm: FC<IReport> = (props: any) => {
+// type ComponentTypes = InspectionType | Date | ManagerCompleted | InspectionArea | StatusTracking | InspectionComments | Manager | Item | NoHazard | InspectionSite | InspectedBy
+
+const InspectionForm: FC<IReport> = () => {
 
     const [ report, setReport ] = useState<IReport>({})
 
@@ -31,15 +33,15 @@ const InspectionForm: FC<IReport> = (props: any) => {
     }
 
     //  Object of small form components
-    const smallComponents: {compName: string, compTitle: string}[] = [
-        {compName: "InspectionType", compTitle: "InspectionType"},
-        {compName: "Date", compTitle: "Date Inspected"},
-        {compName: "ManagerCompleted", compTitle: "ManagerCompleted"},
-        {compName: "InspectionArea", compTitle: "Inspection Area"},
-        {compName: "StatusTracking", compTitle: "Status Tracking"},
-        {compName: "InspectionComments", compTitle: "Inspection Comments"},
-        {compName: "Manager", compTitle: "Manager"},
-        {compName: "NoHazard", compTitle: "No Hazard Found"}
+    const smallComponents: {compName: FC<any>, compTitle: string}[] = [
+        {compName: InspectionType, compTitle: "Inspection Type"},
+        {compName: Date, compTitle: "Date Inspected"},
+        {compName: ManagerCompleted, compTitle: "Manager Completed"},
+        {compName: InspectionArea, compTitle: "Inspection Area"},
+        {compName: StatusTracking, compTitle: "Status Tracking"},
+        {compName: InspectionComments, compTitle: "Inspection Comments"},
+        {compName: Manager, compTitle: "Manager"},
+        {compName: NoHazard, compTitle: "No Hazard Found"}
     ]
 
     return (
@@ -77,11 +79,7 @@ const InspectionForm: FC<IReport> = (props: any) => {
 
                     {smallComponents.map((item, index) => {
                                 return (
-                                    <BaseComponentSmall title={item.compTitle} content={<item.compName setReport={setReport} report={report} {...props}/>} key={index}/>
-                                    // I was receiving an error with the setReport={setReport} that "setReport={setReport} is not assignable to type 'IntrinsicAttributes'"
-                                    // I added the {...props} and added (props:any) to the component declaration
-                                    // I am now displaying the components but not the JSX content of these components
-                                    // The warnings suggest that the BaseComponentSmall component is rendering but the item.compName is not.
+                                    <BaseComponentSmall title={item.compTitle} content={<item.compName setReport={setReport} report={report} />} key={index}/>
                                 )
                             }
                         )

--- a/src/components/form-components/InspectionArea.tsx
+++ b/src/components/form-components/InspectionArea.tsx
@@ -25,7 +25,7 @@ export const InspectionArea = ({ report, setReport}: InspectionAreaProps) => {
     }
 
 
-    return (
+    return (  
         <>
             <FormControl variant="standard" sx={{ m: 1, minWidth: 180, width: "80%" }}>
                 <InputLabel id='inspection_area_level'>Level</InputLabel>
@@ -58,7 +58,6 @@ export const InspectionArea = ({ report, setReport}: InspectionAreaProps) => {
                 </Select>
             </FormControl>        
         </>
-
     );
 }
 

--- a/src/components/form-components/InspectionSite.tsx
+++ b/src/components/form-components/InspectionSite.tsx
@@ -1,4 +1,5 @@
-import { FormControlLabel, Radio, RadioGroup, Grid } from "@mui/material";
+import {FormControlLabel, Radio, RadioGroup, Typography, Paper, Grid} from "@mui/material";
+import { PaperDesign, TitleDesign } from "../../design/Styling";
 import SiteList from "../../data/SiteList";
 import { IReport } from "../../data/Interfaces";
 
@@ -14,6 +15,26 @@ const InspectionSite = ({report, setReport}:InspectionSiteProps) => {
     }
 
     return (
+        <Paper
+        elevation={6}
+        sx={{
+            ...PaperDesign,
+            paddingTop: "30px",
+            height: "auto",                  
+        }}
+        >
+        <Typography
+        variant="h4"
+        sx={         
+            {
+                ...TitleDesign,
+                marginBottom: "30px",
+            }
+        }      
+        >
+            Inspection Site
+        </Typography>  
+
             <RadioGroup aria-label="inspection_site" name="inspection_site"
                 value={report.inspectionSite}
                 onChange={handleChange} 
@@ -38,6 +59,7 @@ const InspectionSite = ({report, setReport}:InspectionSiteProps) => {
                     ))}
                 </Grid>
             </RadioGroup>
+        </Paper>
     );
 }
 

--- a/src/components/form-components/InspectionType.tsx
+++ b/src/components/form-components/InspectionType.tsx
@@ -7,7 +7,7 @@ interface InspectionTypeProps {
     setReport: (report: IReport) => void
 }
 
-export const InspectionType: React.FC<InspectionTypeProps> = ({ report, setReport }:InspectionTypeProps) => {
+export const InspectionType = ({ report, setReport }:InspectionTypeProps) => {
 
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         setReport({...report, inspectionType: event.target.value})

--- a/src/components/form-components/Item.tsx
+++ b/src/components/form-components/Item.tsx
@@ -1,8 +1,9 @@
-import { FormControlLabel, Radio, RadioGroup, Typography, TextField, Button } from "@mui/material";
+import {FormControlLabel, Radio, RadioGroup, Typography, Paper, TextField, Button} from "@mui/material";
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { useState, FC } from "react";
+import {useState, FC} from "react";
+import { PaperDesign, TitleDesign } from "../../design/Styling";
 
 const Hazard: FC = () => {
     const [value, setValue] = useState("");
@@ -14,7 +15,23 @@ const Hazard: FC = () => {
     }
 
     return (
-        <>
+        <Paper
+        elevation={6}
+        sx={
+            {
+                ...PaperDesign,
+                paddingTop: "30px",                  
+            }
+        }
+      >
+        <Typography
+          variant="h4"
+          sx={
+            TitleDesign
+          }      
+        >
+            Inspection Hazard Details
+        </Typography>  
             <TextField
                 id="hazard_item_number_one"
                 label="Unsafe Conditions and/or Acts"
@@ -59,8 +76,9 @@ const Hazard: FC = () => {
                 }}
                 renderInput={(params) => <TextField {...params} sx={{ mb: "20px" }} />}
                 />
-            </LocalizationProvider>        
-        </>
+            </LocalizationProvider>
+
+        </Paper>
     );
 }
 

--- a/src/design/BaseComponentSmall.tsx
+++ b/src/design/BaseComponentSmall.tsx
@@ -1,6 +1,5 @@
 import { Paper, Typography, Grid } from '@mui/material';
 import { PaperDesign, TitleDesign } from './Styling'
-import { IReport } from '../data/Interfaces'
 
 interface BaseComponentSmallProps {
     title: string


### PR DESCRIPTION
const smallComponents compName type was changed from string to FC<Any> to make sure children components were passing props.  Prior to change setReport={setREport } and report={report} were not passing through the BaseCommponentSmall